### PR TITLE
Return machine hostname instead of the IP in the ApplicationHostnameStrategy

### DIFF
--- a/src/Unleash/Strategies/ApplicationHostnameStrategy.cs
+++ b/src/Unleash/Strategies/ApplicationHostnameStrategy.cs
@@ -5,6 +5,7 @@ namespace Unleash.Strategies
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
 
     /// <inheritdoc />
     public class ApplicationHostnameStrategy : IStrategy
@@ -17,7 +18,7 @@ namespace Unleash.Strategies
         /// <inheritdoc />
         public ApplicationHostnameStrategy()
         {
-            hostname = UnleashExtensions.GetLocalIpAddress();
+            hostname = Environment.GetEnvironmentVariable("hostname") ?? Dns.GetHostName();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
In the `ApplicationHostnameStrategy`, if the `hostname` environment variable is not set, the `hostname` should be the machine name obtained using `Dns.GetHostName()`. This is in sync with the other Unleash client implementations:

- [unleash/unleash-client-java](https://github.com/Unleash/unleash-client-java/blob/3ba8b257bf78b30f5c60a4e05c48f8bb23b9335f/src/main/java/no/finn/unleash/strategy/ApplicationHostnameStrategy.java#L22:68)
- [unleash/unleash-client-node](https://github.com/Unleash/unleash-client-node/blob/e94e04cfa6e2022bd7439fb9e462de45161fea56/src/strategy/application-hostname-strategy.ts#L9)
- [unleash/unleash-client-go](https://github.com/Unleash/unleash-client-go/blob/c586a9e5f31e9788ba0dc3f0726150717330d971/internal/strategies/helpers.go#L21)