### PR TITLE
use relative url

### DIFF
--- a/src/Unleash/Communication/UnleashApiClient.cs
+++ b/src/Unleash/Communication/UnleashApiClient.cs
@@ -30,7 +30,7 @@ namespace Unleash.Communication
 
         public async Task<FetchTogglesResult> FetchToggles(string etag, CancellationToken cancellationToken)
         {
-            const string resourceUri = "/api/client/features";
+            const string resourceUri = "api/client/features";
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, resourceUri))
             {


### PR DESCRIPTION
I need to make this change as our unleashed server does not run at the root of the web server. All your other end points are relative so I'm not sure why this is absolute.