### PR TITLE
Changed typo newer to never

### DIFF
--- a/src/Unleash/UnleashSettings.cs
+++ b/src/Unleash/UnleashSettings.cs
@@ -130,7 +130,7 @@ namespace Unleash
             sb.AppendLine($"Fetch toggles interval: {FetchTogglesInterval.TotalSeconds} seconds");
             var metricsInterval = SendMetricsInterval.HasValue
                 ? $"{SendMetricsInterval.Value.TotalSeconds} seconds"
-                : "newer";
+                : "never";
             sb.AppendLine($"Send metrics interval: {metricsInterval}");
 
             sb.AppendLine($"Local storage folder: {LocalStorageFolder()}");


### PR DESCRIPTION
"Send metrics interval: newer/never" means two different things and can confuse those who uses the library.

As an example I was waiting for the instance(s) to be available in Unleash's "Applications" page. Browsing the log saying "newer" I thought everything was supposed to be ok. [After some debugging](https://github.com/Unleash/unleash/issues/340) it turned out to be this typo which threw me off.