### PR TITLE
Added method to IUnleash that enables caller to provide runtime data.

### DIFF
--- a/src/Unleash.Tests/Communication/BaseUnleashApiClientTest.cs
+++ b/src/Unleash.Tests/Communication/BaseUnleashApiClientTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using Unleash.Communication;
 using Unleash.Serialization;
 
@@ -31,8 +32,8 @@ namespace Unleash.Tests.Communication
 
         internal IUnleashApiClient api
         {
-            get => TestContext.CurrentContext.Test.Properties.Get("api") as IUnleashApiClient;
-            set => TestContext.CurrentContext.Test.Properties.Set("api", value);
+            get => TestExecutionContext.CurrentContext.CurrentTest.Properties.Get("api") as IUnleashApiClient;
+            set => TestExecutionContext.CurrentContext.CurrentTest.Properties.Set("api", value);
         }
 
         [SetUp]

--- a/src/Unleash.Tests/Unleash.Tests.csproj
+++ b/src/Unleash.Tests/Unleash.Tests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.3.14.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.14.0\build\net35\NUnit3TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -53,8 +55,8 @@
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.4.12\lib\net45\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -80,6 +82,7 @@
     <Compile Include="Scheduling\SystemTimerScheduledTaskManagerTests.cs" />
     <Compile Include="Strategy\StrategyUtilsTests.cs" />
     <Compile Include="Synchronization\SynchronizationTests.cs" />
+    <Compile Include="UnleashContextTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -132,4 +135,11 @@
   <ItemGroup />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.14.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.14.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
+  </Target>
 </Project>

--- a/src/Unleash.Tests/UnleashContextTests.cs
+++ b/src/Unleash.Tests/UnleashContextTests.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Unleash.Tests
+{
+    public class UnleashContextTests
+    {
+        [Test]
+        public void Clone_FilledUnleashContext_ReturnsNewEquivalentUnleashContext()
+        {
+            var sut = new UnleashContext();
+
+            var clonedContext = sut.Clone();
+
+            clonedContext.Should().NotBe(sut);
+            clonedContext.ShouldBeEquivalentTo(sut);
+        }
+
+        [Test]
+        public void AppendProperties_UnleashContextPropertiesAreEmpty_AppendsPropertiesToUnleashContext()
+        {
+            var sut = new UnleashContext();
+            var properties = new Dictionary<string, string>()
+            {
+                { "property1", "value1" },
+                { "property2", "value2" }
+            };
+
+            sut.AppendProperties(properties);
+
+            sut.Properties.Should().Equal(properties);
+        }
+
+        [Test]
+        public void AppendProperties_PropertiesThatAreNotInTheUnleashContext_AppendsPropertiesToUnleashContext()
+        {
+            var property1 = new KeyValuePair<string, string>("property1", "value1");
+            var property2 = new KeyValuePair<string, string>("property2", "value2");
+
+            var sut = new UnleashContext
+            {
+                Properties = new Dictionary<string, string>
+                {
+                    { property1.Key, property1.Value }
+                }
+            };
+
+            var properties = new Dictionary<string, string>()
+            {
+                { property2.Key, property2.Value }
+            };
+
+            sut.AppendProperties(properties);
+
+            sut.Properties.Should().HaveCount(2);
+            sut.Properties.Should().Contain(new [] { property1, property2 });
+        }
+
+        [Test]
+        public void AppendProperties_PropertyExistsInUnleashContexts_OverwritesPropertyValue()
+        {
+            var sut = new UnleashContext
+            {
+                Properties = new Dictionary<string, string>
+                {
+                    { "property1", "value1" }
+                }
+            };
+
+            var properties = new Dictionary<string, string>
+            {
+                { "property1", "New value1" }
+            };
+
+            sut.AppendProperties(properties);
+
+            sut.Properties.Should().Equal(properties);
+        }
+    }
+}

--- a/src/Unleash.Tests/packages.config
+++ b/src/Unleash.Tests/packages.config
@@ -5,5 +5,6 @@
   <package id="NLog" version="4.4.12" targetFramework="net47" />
   <package id="NLog.Config" version="4.4.12" targetFramework="net47" />
   <package id="NLog.Schema" version="4.4.12" targetFramework="net47" />
-  <package id="NUnit" version="3.8.1" targetFramework="net47" />
+  <package id="NUnit" version="3.12.0" targetFramework="net47" />
+  <package id="NUnit3TestAdapter" version="3.14.0" targetFramework="net47" />
 </packages>

--- a/src/Unleash/DefaultUnleash.cs
+++ b/src/Unleash/DefaultUnleash.cs
@@ -55,6 +55,15 @@ namespace Unleash
             return CheckIsEnabled(toggleName, services.ContextProvider.Context, defaultSetting);
         }
 
+        /// <inheritdoc />
+        public bool IsEnabled(string toggleName, Dictionary<string, string> properties, bool defaultSetting = false)
+        {
+            var context = services.ContextProvider.Context.Clone();
+            context.AppendProperties(properties);
+
+            return CheckIsEnabled(toggleName, context, defaultSetting);
+        }
+
         private bool CheckIsEnabled(string toggleName, UnleashContext context, bool defaultSetting)
         {
             var featureToggle = services.ToggleCollection.Instance.GetToggleByName(toggleName);

--- a/src/Unleash/IUnleash.cs
+++ b/src/Unleash/IUnleash.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Unleash
 {
@@ -21,5 +22,17 @@ namespace Unleash
         /// <param name="defaultSetting">If a toggle is not found, default fallback setting will be returned. (default: false)</param>
         /// <returns></returns>
         bool IsEnabled(string toggleName, bool defaultSetting);
+
+        /// <summary>
+        /// Gets a value indicating a feature is available or not.
+        /// </summary>
+        /// <param name="toggleName">The name of the toggle</param>
+        /// <param name="properties">
+        /// Additional properties that are merged with the properties in the <see cref="UnleashContext"/>.
+        /// These properties can be used in custom strategies and enable the strategy to act on runtime values.
+        /// </param>
+        /// <param name="defaultSetting">If a toggle is not found, default fallback setting will be returned. (default: false)</param>
+        /// <returns></returns>
+        bool IsEnabled(string toggleName, Dictionary<string, string> properties, bool defaultSetting = false);
     }
 }

--- a/src/Unleash/UnleashContext.cs
+++ b/src/Unleash/UnleashContext.cs
@@ -13,23 +13,18 @@ namespace Unleash
         public string UserId { get; set; }
         public string SessionId { get; set; }
         public string RemoteAddress { get; set; }
-        public Dictionary<string, string> Properties { get; set; }
+        public Dictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
 
         /// <summary>
         /// Appends the given properties to the <see cref="Properties"/> property.
-        /// Throws an <see cref="ArgumentException"/> if the key of a property is already in the <see cref="Properties"/> property.
+        /// Replaces the value of the property if a property with the same key already exists.
         /// </summary>
         /// <param name="properties"></param>
         internal void AppendProperties(Dictionary<string, string> properties)
         {
             foreach (var property in properties)
             {
-                if (Properties.ContainsKey(property.Key))
-                {
-                    throw new ArgumentException($"A property with the key: {property.Key} already exists in {nameof(Properties)}", nameof(properties));
-                }
-
-                Properties.Add(property.Key, property.Value);
+                Properties[property.Key] = property.Value;
             }
         }
 

--- a/src/Unleash/UnleashContext.cs
+++ b/src/Unleash/UnleashContext.cs
@@ -88,8 +88,6 @@ namespace Unleash
                 };
             }
         }
-
-       
     }
 
     #endregion

--- a/src/Unleash/UnleashContext.cs
+++ b/src/Unleash/UnleashContext.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+
 namespace Unleash
 {
     using System.Collections.Generic;
@@ -11,6 +14,35 @@ namespace Unleash
         public string SessionId { get; set; }
         public string RemoteAddress { get; set; }
         public Dictionary<string, string> Properties { get; set; }
+
+        /// <summary>
+        /// Appends the given properties to the <see cref="Properties"/> property.
+        /// Throws an <see cref="ArgumentException"/> if the key of a property is already in the <see cref="Properties"/> property.
+        /// </summary>
+        /// <param name="properties"></param>
+        internal void AppendProperties(Dictionary<string, string> properties)
+        {
+            foreach (var property in properties)
+            {
+                if (Properties.ContainsKey(property.Key))
+                {
+                    throw new ArgumentException($"A property with the key: {property.Key} already exists in {nameof(Properties)}", nameof(properties));
+                }
+
+                Properties.Add(property.Key, property.Value);
+            }
+        }
+
+        internal UnleashContext Clone()
+        {
+            return new UnleashContext
+            {
+                UserId = UserId,
+                SessionId = SessionId,
+                RemoteAddress = RemoteAddress,
+                Properties = Properties.ToDictionary(p => p.Key, p => p.Value)
+            };
+        }
 
         #region Builder pattern: used in tests
 
@@ -61,6 +93,8 @@ namespace Unleash
                 };
             }
         }
+
+       
     }
 
     #endregion


### PR DESCRIPTION
We would like to be able to pass properties to the IsEnabled method, so the strategies can act on these properties. Currently the only way to provide these properties is through the UnleashContext, but these values are initialized per request, and therefore not flexible enough for all scenario's.